### PR TITLE
Hotfix/receive on byte length fails on etx

### DIFF
--- a/JSS.SimpleNetworkingClient.UnitTests/Integration/FaultTests.cs
+++ b/JSS.SimpleNetworkingClient.UnitTests/Integration/FaultTests.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace JSS.SimpleNetworkingClient.UnitTests.Integration;
+
+public class FaultTests
+{
+    /// <summary>
+    /// Test that checks if the connection to the TcpReceiveConnection closes when the other side closes the connection
+    /// </summary>
+    /// <param name="testData">Data that will be transmitted from the sender to the receiver</param>
+    [Fact]
+    public void SimpleAsyncByteArrayReadWithLengthHeaderShouldSucceed()
+    {
+        byte[] testData = [ 0x30, 0x31, 0x32, 0x33 ];
+        var are = new AutoResetEvent(false);
+        var dataReceived = new AutoResetEvent(false);
+
+        // Start the receiving side
+        var receiveTask = Task.Run(() =>
+        {
+            var settings = (TcpClientSettings)TcpClientSettingFactory.DefaultSettings.Clone();
+            settings.LeadingMessageLengthBytes = 1;
+            using var reader = new TcpReadConnection(settings);
+            var connectionClosed = false;
+            reader.OnConnectionClosed = () =>
+            {
+                connectionClosed = true;
+            };
+
+            reader.StartListening();
+            are.Set();
+            dataReceived.WaitOne(TcpClientSettingFactory.DefaultSettings.SendReadTimeout);
+            if (!connectionClosed)
+                throw new Exception("Connection was not closed");
+        });
+
+        // Wait for the receiver to start listening
+        are.WaitOne(5000);
+
+        // Start sending data
+        var sendTask = Task.Run(async () =>
+        {
+            var settings = (TcpClientSettings)TcpClientSettingFactory.DefaultSettings.Clone();
+            settings.LeadingMessageLengthBytes = 1;
+            using var sendConnection = new TcpSendConnection(settings);
+            await sendConnection.SendData(testData);
+            await Task.Delay(1000);
+            sendConnection.Dispose();
+            await Task.Delay(1000);
+            dataReceived.Set();
+        });
+
+        if (Task.WaitAll(new[] { receiveTask, sendTask }, 30000) == false)
+        {
+            if (receiveTask.Exception != null)
+                throw receiveTask.Exception;
+            if (sendTask.Exception != null)
+                throw sendTask.Exception;
+            
+            throw new TimeoutException("Send or receive task has not completed within the allotted time");
+        }
+    }
+}

--- a/JSS.SimpleNetworkingClient.UnitTests/Integration/TcpClientSettingFactory.cs
+++ b/JSS.SimpleNetworkingClient.UnitTests/Integration/TcpClientSettingFactory.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace JSS.SimpleNetworkingClient.UnitTests.Integration;
+
+public static class TcpClientSettingFactory
+{
+    public static TcpClientSettings DefaultSettings => new ()
+    {
+        Host = "127.0.0.1",
+        Port = 514,
+        SendReadTimeout = TimeSpan.FromSeconds(30),
+        IpStackBufferSize = 1024,
+        StxCharacters = [ 0x02 ],
+        EtxCharacters = [ 0x03 ]
+    };
+}

--- a/JSS.SimpleNetworkingClient.UnitTests/Integration/TcpReaderTests.cs
+++ b/JSS.SimpleNetworkingClient.UnitTests/Integration/TcpReaderTests.cs
@@ -64,7 +64,7 @@ namespace JSS.SimpleNetworkingClient.UnitTests.Integration
         }
         
         /// <summary>
-        /// Test that the TcpReadConnection can receive and respond asynchronously with a byte array
+        /// Test that the TcpReadConnection can receive and respond asynchronously with a byte array and a length header
         /// </summary>
         /// <param name="testData">Data that will be transmitted from the sender to the receiver</param>
         [Theory]
@@ -84,7 +84,7 @@ namespace JSS.SimpleNetworkingClient.UnitTests.Integration
                 reader.OnDataReceived = (returnedData) =>
                 {
                     returnedData.Should().Be(Encoding.Default.GetString(testData));
-                    reader.SendData("ACK", Encoding.UTF8).Wait(_defaultTimeout);
+                    reader.SendData(testData).Wait(_defaultTimeout);
                     dataReceived.Set();
                 };
 
@@ -103,7 +103,60 @@ namespace JSS.SimpleNetworkingClient.UnitTests.Integration
                 settings.LeadingMessageLengthBytes = 1;
                 using var sendConnection = new TcpSendConnection(settings);
                 await sendConnection.SendData(testData);
-                sendConnection.ReceiveDataAsString().Should().Be("ACK");
+                sendConnection.ReceiveDataAsByteArray().Should().BeEquivalentTo(testData);
+            });
+
+            if (Task.WaitAll(new[] { receiveTask, sendTask }, 30000) == false)
+                throw new TimeoutException("Send or receive task has not completed within the allotted time");
+
+            // Make sure that exceptions on other thread tasks fail the unit test
+            if (receiveTask.Exception != null)
+                throw receiveTask.Exception;
+            if (sendTask.Exception != null)
+                throw sendTask.Exception;
+        }
+        
+        /// <summary>
+        /// Test that the TcpReadConnection can receive and respond asynchronously with a string and a length header
+        /// </summary>
+        /// <param name="testData">Data that will be transmitted from the sender to the receiver</param>
+        [Theory]
+        [InlineData(new byte[] { 0x30, 0x31, 0x32, 0x33 })]
+        [InlineData(new byte[] { 0x30, 0x31, 0x03, 0x33 })]
+        public void SimpleAsyncStringReadWithLengthHeaderShouldSucceed(byte[] testData)
+        {
+            var are = new AutoResetEvent(false);
+
+            // Start the receiving side
+            var receiveTask = Task.Run(async () =>
+            {
+                var settings = (TcpClientSettings)DefaultSettings.Clone();
+                settings.LeadingMessageLengthBytes = 1;
+                var dataReceived = new AutoResetEvent(false);
+                using var reader = new TcpReadConnection(settings);
+                reader.OnDataReceived = (returnedData) =>
+                {
+                    returnedData.Should().Be(Encoding.Default.GetString(testData));
+                    reader.SendData(testData).Wait(_defaultTimeout);
+                    dataReceived.Set();
+                };
+
+                reader.StartListening();
+                are.Set();
+                dataReceived.WaitOne(_defaultTimeout);
+            });
+
+            // Wait for the receiver to start listening
+            are.WaitOne(5000);
+
+            // Start sending data
+            var sendTask = Task.Run(async () =>
+            {
+                var settings = (TcpClientSettings)DefaultSettings.Clone();
+                settings.LeadingMessageLengthBytes = 1;
+                using var sendConnection = new TcpSendConnection(settings);
+                await sendConnection.SendData(testData);
+                sendConnection.ReceiveDataAsString().Should().Be(Encoding.Default.GetString(testData));
             });
 
             if (Task.WaitAll(new[] { receiveTask, sendTask }, 30000) == false)

--- a/JSS.SimpleNetworkingClient.UnitTests/Integration/TcpReaderTests.cs
+++ b/JSS.SimpleNetworkingClient.UnitTests/Integration/TcpReaderTests.cs
@@ -11,10 +11,6 @@ namespace JSS.SimpleNetworkingClient.UnitTests.Integration
 {
     public class TcpReaderTests
     {
-        private const string LocalHost = "127.0.0.1";
-        private const int Port = 514;
-        private TimeSpan _defaultTimeout = TimeSpan.FromSeconds(30);
-
         /// <summary>
         /// Test that the TcpReadConnection can receive and respond asynchronously with a string
         /// </summary>
@@ -29,17 +25,17 @@ namespace JSS.SimpleNetworkingClient.UnitTests.Integration
             var receiveTask = Task.Run(async () =>
             {
                 var dataReceived = new AutoResetEvent(false);
-                using var reader = new TcpReadConnection(DefaultSettings);
+                using var reader = new TcpReadConnection(TcpClientSettingFactory.DefaultSettings);
                 reader.OnDataReceived = (returnedData) =>
                 {
                     returnedData.Should().Be(testData);
-                    reader.SendData("ACK", Encoding.UTF8).Wait(_defaultTimeout);
+                    reader.SendData("ACK", Encoding.UTF8).Wait(TcpClientSettingFactory.DefaultSettings.SendReadTimeout);
                     dataReceived.Set();
                 };
 
                 reader.StartListening();
                 are.Set();
-                dataReceived.WaitOne(_defaultTimeout);
+                dataReceived.WaitOne(TcpClientSettingFactory.DefaultSettings.SendReadTimeout);
             });
 
             // Wait for the receiver to start listening
@@ -48,7 +44,7 @@ namespace JSS.SimpleNetworkingClient.UnitTests.Integration
             // Start sending data
             var sendTask = Task.Run(async () =>
             {
-                using var sendConnection = new TcpSendConnection(DefaultSettings);
+                using var sendConnection = new TcpSendConnection(TcpClientSettingFactory.DefaultSettings);
                 await sendConnection.SendData(testData, Encoding.UTF8);
                 sendConnection.ReceiveDataAsString().Should().Be("ACK");
             });
@@ -77,20 +73,20 @@ namespace JSS.SimpleNetworkingClient.UnitTests.Integration
             // Start the receiving side
             var receiveTask = Task.Run(async () =>
             {
-                var settings = (TcpClientSettings)DefaultSettings.Clone();
+                var settings = (TcpClientSettings)TcpClientSettingFactory.DefaultSettings.Clone();
                 settings.LeadingMessageLengthBytes = 1;
                 var dataReceived = new AutoResetEvent(false);
                 using var reader = new TcpReadConnection(settings);
                 reader.OnDataReceived = (returnedData) =>
                 {
                     returnedData.Should().Be(Encoding.Default.GetString(testData));
-                    reader.SendData(testData).Wait(_defaultTimeout);
+                    reader.SendData(testData).Wait(TcpClientSettingFactory.DefaultSettings.SendReadTimeout);
                     dataReceived.Set();
                 };
 
                 reader.StartListening();
                 are.Set();
-                dataReceived.WaitOne(_defaultTimeout);
+                dataReceived.WaitOne(TcpClientSettingFactory.DefaultSettings.SendReadTimeout);
             });
 
             // Wait for the receiver to start listening
@@ -99,7 +95,7 @@ namespace JSS.SimpleNetworkingClient.UnitTests.Integration
             // Start sending data
             var sendTask = Task.Run(async () =>
             {
-                var settings = (TcpClientSettings)DefaultSettings.Clone();
+                var settings = (TcpClientSettings)TcpClientSettingFactory.DefaultSettings.Clone();
                 settings.LeadingMessageLengthBytes = 1;
                 using var sendConnection = new TcpSendConnection(settings);
                 await sendConnection.SendData(testData);
@@ -130,20 +126,20 @@ namespace JSS.SimpleNetworkingClient.UnitTests.Integration
             // Start the receiving side
             var receiveTask = Task.Run(async () =>
             {
-                var settings = (TcpClientSettings)DefaultSettings.Clone();
+                var settings = (TcpClientSettings)TcpClientSettingFactory.DefaultSettings.Clone();
                 settings.LeadingMessageLengthBytes = 1;
                 var dataReceived = new AutoResetEvent(false);
                 using var reader = new TcpReadConnection(settings);
                 reader.OnDataReceived = (returnedData) =>
                 {
                     returnedData.Should().Be(Encoding.Default.GetString(testData));
-                    reader.SendData(testData).Wait(_defaultTimeout);
+                    reader.SendData(testData).Wait(TcpClientSettingFactory.DefaultSettings.SendReadTimeout);
                     dataReceived.Set();
                 };
 
                 reader.StartListening();
                 are.Set();
-                dataReceived.WaitOne(_defaultTimeout);
+                dataReceived.WaitOne(TcpClientSettingFactory.DefaultSettings.SendReadTimeout);
             });
 
             // Wait for the receiver to start listening
@@ -152,7 +148,7 @@ namespace JSS.SimpleNetworkingClient.UnitTests.Integration
             // Start sending data
             var sendTask = Task.Run(async () =>
             {
-                var settings = (TcpClientSettings)DefaultSettings.Clone();
+                var settings = (TcpClientSettings)TcpClientSettingFactory.DefaultSettings.Clone();
                 settings.LeadingMessageLengthBytes = 1;
                 using var sendConnection = new TcpSendConnection(settings);
                 await sendConnection.SendData(testData);
@@ -187,11 +183,11 @@ namespace JSS.SimpleNetworkingClient.UnitTests.Integration
                     return;
 
                 var dataReceived = new AutoResetEvent(false);
-                using var reader = new TcpReadConnection(DefaultSettings);
+                using var reader = new TcpReadConnection(TcpClientSettingFactory.DefaultSettings);
                 reader.OnDataReceived = (returnedData) =>
                 {
                     returnedData.Should().Be(testData);
-                    reader.SendData("ACK", Encoding.UTF8).Wait(_defaultTimeout);
+                    reader.SendData("ACK", Encoding.UTF8).Wait(TcpClientSettingFactory.DefaultSettings.SendReadTimeout);
                     receiveCounter++;
 
                     if (receiveCounter == 100)
@@ -210,7 +206,7 @@ namespace JSS.SimpleNetworkingClient.UnitTests.Integration
             {
                 for (int i = 0; i < 100; i++)
                 {
-                    using var sendConnection = new TcpSendConnection(DefaultSettings);
+                    using var sendConnection = new TcpSendConnection(TcpClientSettingFactory.DefaultSettings);
                     await sendConnection.SendData(testData, Encoding.UTF8);
                     sendConnection.ReceiveDataAsString().Should().Be("ACK");
                 }
@@ -244,11 +240,11 @@ namespace JSS.SimpleNetworkingClient.UnitTests.Integration
                     return;
 
                 var dataReceived = new AutoResetEvent(false);
-                using var reader = new TcpReadConnection(DefaultSettings);
+                using var reader = new TcpReadConnection(TcpClientSettingFactory.DefaultSettings);
                 reader.OnDataReceived = (returnedData) =>
                 {
                     returnedData.Should().Be(testData);
-                    reader.SendData("ACK", Encoding.UTF8).Wait(_defaultTimeout);
+                    reader.SendData("ACK", Encoding.UTF8).Wait(TcpClientSettingFactory.DefaultSettings.SendReadTimeout);
                     receiveCounter++;
 
                     if (receiveCounter == 100)
@@ -265,7 +261,7 @@ namespace JSS.SimpleNetworkingClient.UnitTests.Integration
             // Start sending data
             var sendTask = Task.Run(async () =>
             {
-                using var sendConnection = new TcpSendConnection(DefaultSettings);
+                using var sendConnection = new TcpSendConnection(TcpClientSettingFactory.DefaultSettings);
                 
                 for (int i = 0; i < 100; i++)
                 {
@@ -299,10 +295,10 @@ namespace JSS.SimpleNetworkingClient.UnitTests.Integration
             // Start the receiving side
             var receiveTask = Task.Run(async () =>
             {
-                using var reader = new TcpReadConnection(DefaultSettings);
+                using var reader = new TcpReadConnection(TcpClientSettingFactory.DefaultSettings);
                 reader.StartListening();
                 are.Set();
-                var result = await reader.WaitForData(_defaultTimeout);
+                var result = await reader.WaitForData(TcpClientSettingFactory.DefaultSettings.SendReadTimeout);
                 await reader.SendData("ACK", Encoding.UTF8);
                 result.Should().Be(testData);
             });
@@ -313,7 +309,7 @@ namespace JSS.SimpleNetworkingClient.UnitTests.Integration
             // Start sending data
             var sendTask = Task.Run(async () =>
             {
-                using var sendConnection = new TcpSendConnection(DefaultSettings);
+                using var sendConnection = new TcpSendConnection(TcpClientSettingFactory.DefaultSettings);
                 await sendConnection.SendData(testData, Encoding.UTF8);
                 sendConnection.ReceiveDataAsString().Should().Be("ACK");
             });
@@ -345,7 +341,7 @@ namespace JSS.SimpleNetworkingClient.UnitTests.Integration
             var receiveTask = Task.Run(async () =>
             {
                 var dataReceived = new AutoResetEventEx(false);
-                using var reader = new TcpReadConnection(DefaultSettings);
+                using var reader = new TcpReadConnection(TcpClientSettingFactory.DefaultSettings);
                 reader.OnDataReceived = (returnedData) =>
                 {
                     try
@@ -364,7 +360,7 @@ namespace JSS.SimpleNetworkingClient.UnitTests.Integration
 
                 reader.StartListening();
                 are.Set();
-                dataReceived.WaitOne(_defaultTimeout);
+                dataReceived.WaitOne(TcpClientSettingFactory.DefaultSettings.SendReadTimeout);
             });
 
             // Wait for the receiver to start listening
@@ -373,7 +369,7 @@ namespace JSS.SimpleNetworkingClient.UnitTests.Integration
             // Start sending data
             var sendTask = Task.Run(async () =>
             {
-                using var sendConnection = new TcpSendConnection(DefaultSettings);
+                using var sendConnection = new TcpSendConnection(TcpClientSettingFactory.DefaultSettings);
                 foreach (var dataToSend in testData)
                     await sendConnection.SendData(dataToSend, Encoding.UTF8);
             });
@@ -395,7 +391,7 @@ namespace JSS.SimpleNetworkingClient.UnitTests.Integration
             var resultCounter = 0;
             string[] testData = [ "qwertyuiop", "asdfghjkl", "zxcvbnm,./", "qwertyuiop", "asdfghjkl", "zxcvbnm,./" ];
 
-            var settings = (TcpClientSettings)DefaultSettings.Clone();
+            var settings = (TcpClientSettings)TcpClientSettingFactory.DefaultSettings.Clone();
             settings.LeadingMessageLengthBytes = 4;
 
             // Start the receiving side
@@ -421,7 +417,7 @@ namespace JSS.SimpleNetworkingClient.UnitTests.Integration
 
                 reader.StartListening();
                 are.Set();
-                dataReceived.WaitOne(_defaultTimeout);
+                dataReceived.WaitOne(TcpClientSettingFactory.DefaultSettings.SendReadTimeout);
             });
 
             // Wait for the receiver to start listening
@@ -446,15 +442,5 @@ namespace JSS.SimpleNetworkingClient.UnitTests.Integration
             if (sendTask.Exception != null)
                 throw sendTask.Exception;
         }
-
-        private TcpClientSettings DefaultSettings => new ()
-        {
-            Host = LocalHost,
-            Port = Port,
-            SendReadTimeout = _defaultTimeout,
-            IpStackBufferSize = 1024,
-            StxCharacters = [ 0x02 ],
-            EtxCharacters = [ 0x03 ]
-        };
     }
 }

--- a/JSS.SimpleNetworkingClient.UnitTests/Integration/TcpReaderTests.cs
+++ b/JSS.SimpleNetworkingClient.UnitTests/Integration/TcpReaderTests.cs
@@ -16,12 +16,12 @@ namespace JSS.SimpleNetworkingClient.UnitTests.Integration
         private TimeSpan _defaultTimeout = TimeSpan.FromSeconds(30);
 
         /// <summary>
-        /// Test that the TcpReadConnection can receive and respond asynchronously
+        /// Test that the TcpReadConnection can receive and respond asynchronously with a string
         /// </summary>
         /// <param name="testData">Data that will be transmitted from the sender to the receiver</param>
         [Theory]
         [InlineData("qwertyuiop")]
-        public void SimpleAsyncReadShouldSucceed(string testData)
+        public void SimpleAsyncStringReadShouldSucceed(string testData)
         {
             var are = new AutoResetEvent(false);
 
@@ -50,6 +50,59 @@ namespace JSS.SimpleNetworkingClient.UnitTests.Integration
             {
                 using var sendConnection = new TcpSendConnection(DefaultSettings);
                 await sendConnection.SendData(testData, Encoding.UTF8);
+                sendConnection.ReceiveDataAsString().Should().Be("ACK");
+            });
+
+            if (Task.WaitAll(new[] { receiveTask, sendTask }, 30000) == false)
+                throw new TimeoutException("Send or receive task has not completed within the allotted time");
+
+            // Make sure that exceptions on other thread tasks fail the unit test
+            if (receiveTask.Exception != null)
+                throw receiveTask.Exception;
+            if (sendTask.Exception != null)
+                throw sendTask.Exception;
+        }
+        
+        /// <summary>
+        /// Test that the TcpReadConnection can receive and respond asynchronously with a byte array
+        /// </summary>
+        /// <param name="testData">Data that will be transmitted from the sender to the receiver</param>
+        [Theory]
+        [InlineData(new byte[] { 0x30, 0x31, 0x32, 0x33 })]
+        [InlineData(new byte[] { 0x30, 0x31, 0x03, 0x33 })]
+        public void SimpleAsyncByteArrayReadWithLengthHeaderShouldSucceed(byte[] testData)
+        {
+            var are = new AutoResetEvent(false);
+
+            // Start the receiving side
+            var receiveTask = Task.Run(async () =>
+            {
+                var settings = (TcpClientSettings)DefaultSettings.Clone();
+                settings.LeadingMessageLengthBytes = 1;
+                var dataReceived = new AutoResetEvent(false);
+                using var reader = new TcpReadConnection(settings);
+                reader.OnDataReceived = (returnedData) =>
+                {
+                    returnedData.Should().Be(Encoding.Default.GetString(testData));
+                    reader.SendData("ACK", Encoding.UTF8).Wait(_defaultTimeout);
+                    dataReceived.Set();
+                };
+
+                reader.StartListening();
+                are.Set();
+                dataReceived.WaitOne(_defaultTimeout);
+            });
+
+            // Wait for the receiver to start listening
+            are.WaitOne(5000);
+
+            // Start sending data
+            var sendTask = Task.Run(async () =>
+            {
+                var settings = (TcpClientSettings)DefaultSettings.Clone();
+                settings.LeadingMessageLengthBytes = 1;
+                using var sendConnection = new TcpSendConnection(settings);
+                await sendConnection.SendData(testData);
                 sendConnection.ReceiveDataAsString().Should().Be("ACK");
             });
 

--- a/JSS.SimpleNetworkingClient.UnitTests/Unit/UtilTests.cs
+++ b/JSS.SimpleNetworkingClient.UnitTests/Unit/UtilTests.cs
@@ -11,9 +11,21 @@ namespace JSS.SimpleNetworkingClient.UnitTests.Unit
         {
             byte[] lengthStruct = [ 253, 254, 0, 0 ];
             TcpLengthUtils.GetMessageLength(lengthStruct, 4, false).Should().Be(65277);
-            
+
             lengthStruct = [ 0, 0, 254, 253, 1, 2 ];
             TcpLengthUtils.GetMessageLength(lengthStruct, 4, true).Should().Be(65277);
+
+            lengthStruct = [ 253 ];
+            TcpLengthUtils.GetMessageLength(lengthStruct, 1, false).Should().Be(253);
+
+            lengthStruct = [ 253 ];
+            TcpLengthUtils.GetMessageLength(lengthStruct, 1, true).Should().Be(253);
+            
+            lengthStruct = [ 253, 0 ];
+            TcpLengthUtils.GetMessageLength(lengthStruct, 2, false).Should().Be(253);
+
+            lengthStruct = [ 0, 253 ];
+            TcpLengthUtils.GetMessageLength(lengthStruct, 2, true).Should().Be(253);
         }
     }
 }

--- a/JSS.SimpleNetworkingClient/TcpConnectionBase.cs
+++ b/JSS.SimpleNetworkingClient/TcpConnectionBase.cs
@@ -71,9 +71,11 @@ public abstract class TcpConnectionBase : IDisposable
         var payloadBytesRead = 0;
 
         // Check how many bytes will be send by the remote party
-        var lengthBuffer = new byte[Settings.LeadingMessageLengthBytes + stxCharacters.Length];
-        var lengtBytesRead = await stream.ReadAsync(lengthBuffer, 0, Settings.LeadingMessageLengthBytes + stxCharacters.Length);
-        if (lengtBytesRead != Settings.LeadingMessageLengthBytes)
+        var expectedLeadingBytes = Settings.LeadingMessageLengthBytes + stxCharacters.Length;
+        var lengthBuffer = new byte[expectedLeadingBytes];
+        var lengtBytesRead = await stream.ReadAsync(lengthBuffer, 0, expectedLeadingBytes);
+        if (lengtBytesRead != expectedLeadingBytes)
+            throw new NetworkingException($"Leading message length bytes with STX character length({expectedLeadingBytes}) is shorter than the nr of bytes({lengtBytesRead}) received.", NetworkingException.NetworkingExceptionTypeEnum.InvalidDataStreamLength);
         
         // Check for the stx characters
         if (!lengthBuffer.AsSpan().StartsWith(stxCharacters.AsSpan()))

--- a/JSS.SimpleNetworkingClient/TcpConnectionBase.cs
+++ b/JSS.SimpleNetworkingClient/TcpConnectionBase.cs
@@ -99,13 +99,15 @@ public abstract class TcpConnectionBase : IDisposable
         while (bytesRemaining > 0)
         {
             // Detect if the connection has been closed, reset or terminated. Stays true on Windows even after the remote party disconnected.
-            if (TcpClient.Connected == false)
+            if (PollTcpClient() == false)
                 throw new NetworkingException($"Networking socket has been closed by the remote party", NetworkingException.NetworkingExceptionTypeEnum.ConnectionAbortedPrematurely);
 
             // Check if the read has timed out. The TcpClient has a mechanism for this but it is not reliable
             if (DateTime.Now > _timeoutTimer + Settings.SendReadTimeout)
                 throw new NetworkingException($"Reading of tcp data timed out. Timeout set to {Settings.SendReadTimeout.TotalMilliseconds} ms", NetworkingException.NetworkingExceptionTypeEnum.ReadTimeout);
 
+            // Read until the end of the nr of expected bytes based on the length header
+            // This means we don't have to take into account that multiple messages are present in the TcpClient stream
             actualBytesRead = await stream.ReadAsync(totalBuffer, payloadBytesRead, bytesToRead);
             payloadBytesRead += actualBytesRead;
             
@@ -170,18 +172,6 @@ public abstract class TcpConnectionBase : IDisposable
         // Read all the data until the tcp connection has been closed
         while (PollTcpClient())
         {
-            // Detect if there is an error on the socket
-            if (TcpClient.Client.Poll(1, SelectMode.SelectError))
-                throw new NetworkingException($"Networking socket is in an error state", NetworkingException.NetworkingExceptionTypeEnum.SocketError);
-
-            // Detect if the connection has been closed, reset or terminated
-            if (TcpClient.Client.Connected == false || TcpClient.Available == 0)
-                throw new NetworkingException($"Connection has been closed, reset or terminated", NetworkingException.NetworkingExceptionTypeEnum.SocketError);
-
-            // Check if the read has timed out. The TcpClient.Connected mechanism is not reliable
-            if (DateTime.Now > _timeoutTimer + Settings.SendReadTimeout)
-                throw new NetworkingException($"Reading of tcp data timed out. Timeout set to {Settings.SendReadTimeout.TotalMilliseconds} ms", NetworkingException.NetworkingExceptionTypeEnum.ReadTimeout);
-
             // Read available data and get the nr of bytes received
             var bytesRead = stream.Read(_loopBuffer, 0, Settings.IpStackBufferSize);
             
@@ -363,13 +353,31 @@ public abstract class TcpConnectionBase : IDisposable
     /// <summary>
     /// Polls the underlying winsock connection to detect if data can be read
     /// </summary>
-    /// <returns>True to indicate that data is available or the connection has been closed. False to indicate the connection is not readable</returns>
+    /// <returns>True to indicate that data is available or the connection is open. False to indicate the connection is not readable</returns>
     /// <remarks>
     /// IMPORTANT: The Poll method only blocks when the connection is established and data has yet to be send.
     /// That a .Net Socket is reported as being open does not mean that the full connection has been established yet
     /// </remarks>
     private bool PollTcpClient()
-        => TcpClient.Client.Poll(_sendReadTimeoutMicroseconds, SelectMode.SelectRead);
+    {
+        // Poll returns true if data is available or the connection is closed
+        // The _sendReadTimeoutMicroseconds parameter means that the poll will block until data is available -or- it times out -or- the connection is closed -or- DisposeCurrentTcpClient is called externally from another thread
+        var readAvailable = TcpClient.Client.Poll(_sendReadTimeoutMicroseconds, SelectMode.SelectRead);
+        
+        // Detect if there is an error on the socket
+        if (TcpClient.Client.Poll(1, SelectMode.SelectError))
+            throw new NetworkingException($"Networking socket is in an error state", NetworkingException.NetworkingExceptionTypeEnum.SocketError);
+
+        // Detect if the connection has been closed, reset or terminated
+        if (TcpClient.Client.Connected == false || TcpClient.Available == 0)
+            throw new NetworkingException($"Connection has been closed, reset or terminated", NetworkingException.NetworkingExceptionTypeEnum.SocketError);
+
+        // Check if the read has timed out. The TcpClient.Connected mechanism is not reliable
+        if (DateTime.Now > _timeoutTimer + Settings.SendReadTimeout)
+            throw new NetworkingException($"Reading of tcp data timed out. Timeout set to {Settings.SendReadTimeout.TotalMilliseconds} ms", NetworkingException.NetworkingExceptionTypeEnum.ReadTimeout);
+
+        return readAvailable;
+    }
 
     /// <summary>
     /// Disposes the currently active tcp client(if any)

--- a/JSS.SimpleNetworkingClient/TcpReadConnection.cs
+++ b/JSS.SimpleNetworkingClient/TcpReadConnection.cs
@@ -84,6 +84,7 @@ public class TcpReadConnection : TcpConnectionBase, IDisposable
                             while (true)
                             {
                                 // Poll returns true if data is available or the connection is closed
+                                // The -1 parameter means that the poll will block until data is available -or- the connection is closed -or- DisposeCurrentTcpClient is called externally from another thread
                                 var pollResult = TcpClient.Client.Poll(-1, SelectMode.SelectRead);
                                 if (_cancellationTokenSource.IsCancellationRequested)
                                     return;
@@ -104,6 +105,7 @@ public class TcpReadConnection : TcpConnectionBase, IDisposable
                                 {
                                     // Connection has been closed by the remote party
                                     DisposeCurrentTcpClient();
+                                    OnConnectionClosed?.Invoke();
                                     break;
                                 }
                                 else if (pollResult && (MessageBuffer.Any() || TcpClient.Client.Available > 0))
@@ -118,6 +120,7 @@ public class TcpReadConnection : TcpConnectionBase, IDisposable
                                     var writeState = TcpClient.Client.Poll(1, SelectMode.SelectWrite);
                                     Settings.Logger?.Verbose($"Connection is not readable so treat is as dead. Poll states: SelectError={errorState}, SelectRead={pollResult}, SelectWrite={writeState}");
                                     DisposeCurrentTcpClient();
+                                    OnConnectionClosed?.Invoke();
                                     break;
                                 }
                             }
@@ -174,6 +177,11 @@ public class TcpReadConnection : TcpConnectionBase, IDisposable
     /// Action that is executed when new data has been received
     /// </summary>
     public Action<string> OnDataReceived { get; set; }
+
+    /// <summary>
+    /// Action that is executed when a connection has been closed.
+    /// </summary>
+    public Action OnConnectionClosed { get; set; }
 
     /// <summary>
     /// Open the listening socket and start listening for the remote party

--- a/JSS.SimpleNetworkingClient/TcpSendConnection.cs
+++ b/JSS.SimpleNetworkingClient/TcpSendConnection.cs
@@ -83,5 +83,20 @@ public class TcpSendConnection : TcpConnectionBase, IDisposable
     /// Data received from the remote party. If the stx/etx character has been set using the constructor, they will be removed from the begin/end of the received data string.
     /// </returns>
     public byte[] ReceiveDataAsByteArray()
-        => ReadTcpData(Settings.StxCharacters, Settings.EtxCharacters);
+    {
+        byte[] receivedData;
+        if (Settings.LeadingMessageLengthBytes > 0)
+        {
+            // TcpReadConnection has been configured to expect a length header before the actual data
+            var readTcpDataResultString = ReadTcpDataWithLengthHeader(Settings.StxCharacters, Settings.EtxCharacters);
+            if (readTcpDataResultString.Wait(Settings.SendReadTimeout))
+                receivedData = readTcpDataResultString.Result;
+            else
+                throw new NetworkingException($"{nameof(ReceiveDataAsByteArray)} timed out trying to attempt to read data", NetworkingException.NetworkingExceptionTypeEnum.ReadTimeout);
+        }
+        else
+            receivedData = ReadTcpData(Settings.StxCharacters, Settings.EtxCharacters);
+        
+        return receivedData;
+    }
 }

--- a/JSS.SimpleNetworkingClient/Utils/TcpLengthUtils.cs
+++ b/JSS.SimpleNetworkingClient/Utils/TcpLengthUtils.cs
@@ -6,6 +6,9 @@ public static class TcpLengthUtils
 {
     public static int GetMessageLength(byte[] message, short nrOfLeadingBytes, bool littleEndian = false)
     {
+        if (nrOfLeadingBytes > 4)
+            throw new ArgumentOutOfRangeException($"NrOfLeadingBytes cannot be larger than 4. MessageLength: {message.Length}, nrOfLeadingBytes: {nrOfLeadingBytes}");
+        
         if (message.Length < nrOfLeadingBytes)
             throw new ArgumentException($"Message does not contain enough bytes to read the length. MessageLength: {message.Length}, nrOfLeadingBytes: {nrOfLeadingBytes}");
 
@@ -15,6 +18,14 @@ public static class TcpLengthUtils
         if (littleEndian)
             messageLengthBytes.Reverse();
 
+        // BitConverter.ToInt32 requires exactly 4 bytes. Pad it with 0x00 bytes if the length is less than 4.
+        if (messageLengthBytes.Length < 4)
+        {
+            var paddedBytes = new byte[4];
+            messageLengthBytes.CopyTo(paddedBytes);
+            messageLengthBytes = paddedBytes;
+        }
+        
         return BitConverter.ToInt32(messageLengthBytes);
     }
 


### PR DESCRIPTION
Bugfix release so that using the SendData with bytes overload now also supports the tcp length header and various other small fixes