### PR TITLE
- Added support for including the length header in received data via …

### DIFF
--- a/JSS.SimpleNetworkingClient.UnitTests/Integration/TcpReaderTests.cs
+++ b/JSS.SimpleNetworkingClient.UnitTests/Integration/TcpReaderTests.cs
@@ -58,15 +58,15 @@ namespace JSS.SimpleNetworkingClient.UnitTests.Integration
             if (sendTask.Exception != null)
                 throw sendTask.Exception;
         }
-        
+
         /// <summary>
         /// Test that the TcpReadConnection can receive and respond asynchronously with a byte array and a length header
         /// </summary>
         /// <param name="testData">Data that will be transmitted from the sender to the receiver</param>
         [Theory]
-        [InlineData(new byte[] { 0x30, 0x31, 0x32, 0x33 })]
-        [InlineData(new byte[] { 0x30, 0x31, 0x03, 0x33 })]
-        public void SimpleAsyncByteArrayReadWithLengthHeaderShouldSucceed(byte[] testData)
+        [InlineData(new byte[] { 0x30, 0x31, 0x32, 0x33 }, true)]
+        [InlineData(new byte[] { 0x30, 0x31, 0x03, 0x33 }, false)]
+        public void SimpleAsyncByteArrayReadWithLengthHeaderShouldSucceed(byte[] testData, bool includeLengthHeaderInData)
         {
             var are = new AutoResetEvent(false);
 
@@ -75,11 +75,16 @@ namespace JSS.SimpleNetworkingClient.UnitTests.Integration
             {
                 var settings = (TcpClientSettings)TcpClientSettingFactory.DefaultSettings.Clone();
                 settings.LeadingMessageLengthBytes = 1;
+                settings.IncludeLengthHeaderInData = includeLengthHeaderInData;
                 var dataReceived = new AutoResetEvent(false);
                 using var reader = new TcpReadConnection(settings);
                 reader.OnDataReceived = (returnedData) =>
                 {
-                    returnedData.Should().Be(Encoding.Default.GetString(testData));
+                    if (includeLengthHeaderInData)
+                        returnedData.Should().Be(Encoding.Default.GetString(new byte[] { 0x7 }) + Encoding.Default.GetString(testData));
+                    else
+                        returnedData.Should().Be(Encoding.Default.GetString(testData));
+
                     reader.SendData(testData).Wait(TcpClientSettingFactory.DefaultSettings.SendReadTimeout);
                     dataReceived.Set();
                 };
@@ -97,9 +102,13 @@ namespace JSS.SimpleNetworkingClient.UnitTests.Integration
             {
                 var settings = (TcpClientSettings)TcpClientSettingFactory.DefaultSettings.Clone();
                 settings.LeadingMessageLengthBytes = 1;
+                settings.IncludeLengthHeaderInData = includeLengthHeaderInData;
                 using var sendConnection = new TcpSendConnection(settings);
                 await sendConnection.SendData(testData);
-                sendConnection.ReceiveDataAsByteArray().Should().BeEquivalentTo(testData);
+                if (includeLengthHeaderInData)
+                    sendConnection.ReceiveDataAsByteArray().Should().BeEquivalentTo([0x7, ..testData]);
+                else
+                    sendConnection.ReceiveDataAsByteArray().Should().BeEquivalentTo(testData);
             });
 
             if (Task.WaitAll(new[] { receiveTask, sendTask }, 30000) == false)
@@ -111,7 +120,7 @@ namespace JSS.SimpleNetworkingClient.UnitTests.Integration
             if (sendTask.Exception != null)
                 throw sendTask.Exception;
         }
-        
+
         /// <summary>
         /// Test that the TcpReadConnection can receive and respond asynchronously with a string and a length header
         /// </summary>
@@ -262,7 +271,7 @@ namespace JSS.SimpleNetworkingClient.UnitTests.Integration
             var sendTask = Task.Run(async () =>
             {
                 using var sendConnection = new TcpSendConnection(TcpClientSettingFactory.DefaultSettings);
-                
+
                 for (int i = 0; i < 100; i++)
                 {
                     await sendConnection.SendData(testData, Encoding.UTF8);

--- a/JSS.SimpleNetworkingClient/TcpClientSettings.cs
+++ b/JSS.SimpleNetworkingClient/TcpClientSettings.cs
@@ -64,6 +64,11 @@ public class TcpClientSettings : ICloneable
     /// </summary>
     public bool LittleEndian { get; set; }
 
+    /// <summary>
+    /// True to include the length header in the actual data. False to only return the actual data without the length header.
+    /// </summary>
+    public bool IncludeLengthHeaderInData { get; set; }
+
     /// <summary>Creates a new object that is a copy of the current instance.</summary>
     /// <returns>A new object that is a copy of this instance.</returns>
     public object Clone()

--- a/JSS.SimpleNetworkingClient/TcpConnectionBase.cs
+++ b/JSS.SimpleNetworkingClient/TcpConnectionBase.cs
@@ -82,7 +82,8 @@ public abstract class TcpConnectionBase : IDisposable
             throw new NetworkingException($"Parameter {nameof(stxCharacters)} has been set with '{StringUtils.ByteEnumerableToHexString(stxCharacters)}' but these bytes have not been found at the start of transmission", NetworkingException.NetworkingExceptionTypeEnum.WrongStxEtxCharactersReceived);
         
         // Check if the remote party is actually going to return any data
-        var dataStreamTotalLength = TcpLengthUtils.GetMessageLength(lengthBuffer.Skip(Settings.StxCharacters.Length).ToArray(), (short)Settings.LeadingMessageLengthBytes!, Settings.LittleEndian);
+        var lengthBufferBytesWithoutStx = lengthBuffer.Skip(Settings.StxCharacters.Length).ToArray();
+        var dataStreamTotalLength = TcpLengthUtils.GetMessageLength(lengthBufferBytesWithoutStx, (short)Settings.LeadingMessageLengthBytes!, Settings.LittleEndian);
         Settings.Logger?.Debug($"According to the length bytes at the start of the message {dataStreamTotalLength} bytes have been read");
         if (dataStreamTotalLength == 0)
             return [];
@@ -139,7 +140,9 @@ public abstract class TcpConnectionBase : IDisposable
         Settings.Logger?.Verbose($"Total nr of {payloadBytesRead} bytes have been read");
 
         // Remove the stx and etx characters from the total buffer and then return it
-        return totalBuffer.AsSpan(0, payloadBytesRead - etxCharacters.Length).ToArray();
+        return Settings.IncludeLengthHeaderInData 
+            ? [..lengthBufferBytesWithoutStx, ..totalBuffer.AsSpan(0, payloadBytesRead - etxCharacters.Length).ToArray()]
+            : totalBuffer.AsSpan(0, payloadBytesRead - etxCharacters.Length).ToArray();
     }
 
     /// <summary>
@@ -380,7 +383,7 @@ public abstract class TcpConnectionBase : IDisposable
     }
 
     /// <summary>
-    /// Disposes the currently active tcp client(if any)
+    /// Disposes the currently active tcp client (if any)
     /// </summary>
     protected void DisposeCurrentTcpClient()
     {

--- a/Releasenotes.md
+++ b/Releasenotes.md
@@ -1,6 +1,13 @@
 # Release Notes
 
-## Version 2.0.1 (Latest)
+## Version 2.0.2 (Latest)
+
+### Bug fixes
+- Added support for including the length header in received data via the new `IncludeLengthHeaderInData` setting
+- Updated handling in `TcpConnectionBase` to respect this setting and return data accordingly
+- Adjusted integration tests to validate the new feature
+
+## Version 2.0.1
 
 ### Bug fixes
 - Fixed bug that when calling sendConnection.ReceiveDataAsByteArray() it ignored the new functionality that uses a message header with length


### PR DESCRIPTION
…the new `IncludeLengthHeaderInData` setting

- Updated handling in `TcpConnectionBase` to respect this setting and return data accordingly
- Adjusted integration tests to validate the new feature